### PR TITLE
update percona-backup-mongo to 2.2.2

### DIFF
--- a/frameworks/tapr/config/cluster/deploy/mongodb_deployment.yaml
+++ b/frameworks/tapr/config/cluster/deploy/mongodb_deployment.yaml
@@ -254,7 +254,7 @@ spec:
         timeoutSeconds: 1  
   backup:
     enabled: true
-    image: beclab/percona-backup-mongo:2.2.1
+    image: beclab/percona-backup-mongo:2.2.2
     serviceAccountName: percona-server-mongodb-operator
     containerSecurityContext:
       privileged: true


### PR DESCRIPTION
fix: adding pbm-agent startup retries