### PR TITLE
update middleware-operator to 0.1.29

### DIFF
--- a/frameworks/tapr/config/cluster/deploy/middleware_deploy.yaml
+++ b/frameworks/tapr/config/cluster/deploy/middleware_deploy.yaml
@@ -99,7 +99,7 @@ spec:
         - name: DISABLE_TELEMETRY
           value: "false"
       - name: operator-api
-        image: beclab/middleware-operator:0.1.28
+        image: beclab/middleware-operator:0.1.29
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080


### PR DESCRIPTION
fix the bug that caused tapr-middleware to crash and memory leaks during restoration system