### PR TITLE
build: update mongodb-operator to 1.14.2

### DIFF
--- a/build/manifest/images
+++ b/build/manifest/images
@@ -27,7 +27,7 @@ kubesphere/prometheus-operator:v0.55.1
 mirrorgooglecontainers/defaultbackend-amd64:1.4
 openebs/linux-utils:3.3.0
 openebs/provisioner-localpv:3.3.0
-beclab/percona-server-mongodb-operator:1.15.1
+beclab/percona-server-mongodb-operator:1.15.2
 prom/alertmanager:v0.23.0
 prom/node-exporter:v1.3.1
 prom/prometheus:v2.34.0

--- a/frameworks/tapr/config/cluster/deploy/middleware_deploy.yaml
+++ b/frameworks/tapr/config/cluster/deploy/middleware_deploy.yaml
@@ -71,7 +71,7 @@ spec:
       containers:
       # must be first container
       - name: percona-server-mongodb-operator
-        image: beclab/percona-server-mongodb-operator:1.14.1
+        image: beclab/percona-server-mongodb-operator:1.14.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 60000

--- a/frameworks/tapr/config/cluster/deploy/mongodb_deployment.yaml
+++ b/frameworks/tapr/config/cluster/deploy/mongodb_deployment.yaml
@@ -143,7 +143,7 @@ metadata:
   name: mongo-cluster
   namespace: {{ .Release.Namespace }}
 spec:
-  crVersion: 1.15.1
+  crVersion: 1.15.2
   image: percona/percona-server-mongodb:6.0.4-3
   imagePullPolicy: IfNotPresent
   allowUnsafeConfigurations: true


### PR DESCRIPTION
fixed: add a retry mechanism for pinging the primary during MongoDB database restoration