### PR TITLE
add wasm to dify and dify-gateway

### DIFF
--- a/apps/agent/config/user/helm-charts/agent/templates/agent_deploy.yaml
+++ b/apps/agent/config/user/helm-charts/agent/templates/agent_deploy.yaml
@@ -148,7 +148,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       - name: dify-gateway
-        image: beclab/search2-gateway:v0.0.34
+        image: beclab/search2-gateway:v0.0.35
         imagePullPolicy: IfNotPresent
         ports:
           - name: dify-gateway

--- a/apps/nitro/config/cluster/deploy/dify_deploy.yaml
+++ b/apps/nitro/config/cluster/deploy/dify_deploy.yaml
@@ -826,7 +826,7 @@ spec:
               - SYS_ADMIN
       {{- if and .Values.gpu (not (eq .Values.gpu "none" )) }}
       - name: nitro
-        image: 'beclab/nitro:UI_v24'
+        image: 'beclab/nitro:v0.0.1'
         ports:
           - name: nitro-port
             containerPort: 3928


### PR DESCRIPTION
ADD：
- dify: wasm, a new tool for self-hosting llm model

CHANGE:
- dify: change api serving llm in market from nitro to wasm
- dify & dify-gateway: auto set/unset system model-config and Ashia model-config to nitro/wasm/gpt-4 when llm model loading by nitro/wasm/nil (while openai API key configured manually)

BUGFIX:
- dify & dify-gateway: change system model-config to ctx=4096, token=1024 and Ashia model-config to token=1024 in order to ensure model running more stable