### PR TITLE
dify&dify-gateway: fit both cloud and minibox

### DIFF
--- a/apps/agent/config/user/helm-charts/agent/templates/agent_deploy.yaml
+++ b/apps/agent/config/user/helm-charts/agent/templates/agent_deploy.yaml
@@ -148,7 +148,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       - name: dify-gateway
-        image: beclab/search2-gateway:v0.0.35
+        image: beclab/search2-gateway:v0.0.36
         imagePullPolicy: IfNotPresent
         ports:
           - name: dify-gateway

--- a/apps/nitro/config/cluster/deploy/dify_deploy.yaml
+++ b/apps/nitro/config/cluster/deploy/dify_deploy.yaml
@@ -826,7 +826,7 @@ spec:
               - SYS_ADMIN
       {{- if and .Values.gpu (not (eq .Values.gpu "none" )) }}
       - name: nitro
-        image: 'beclab/nitro:v0.0.1'
+        image: 'beclab/nitro:v0.0.2'
         ports:
           - name: nitro-port
             containerPort: 3928


### PR DESCRIPTION
BUGFIX:
- dify: change libfile copy logic to fit both cloud and minibox

CHANGE:
- defy-gateway: model default max-token down to 512 to fit wasm default and minibox