### PR TITLE
fix: orion gpu runtime broken on Ubuntu 22.04

### DIFF
--- a/build/installer/uninstall_cmd.sh
+++ b/build/installer/uninstall_cmd.sh
@@ -124,7 +124,7 @@ remove_cluster(){
     fi
     $sh_c "iptables -F"
 
-    $sh_c "killall /usr/local/bin/containerd"
+    $sh_c "killall /usr/local/bin/containerd || true"
 }
 
 docker_files=(/usr/bin/docker*

--- a/frameworks/GPU/config/gpu/templates/container-runtime.yaml
+++ b/frameworks/GPU/config/gpu/templates/container-runtime.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: container-runtime
-        image: eball/orionx-container-runtime:1.9.3-env_setup_4.2.0-20231030
+        image: eball/orionx-container-runtime:v1.9.3-patch2_env_setup_4.2.0-20240523023502
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -248,7 +248,7 @@ spec:
         command:
         - /bfl-api
         - -u
-        - {{ .Values.bfl.username }}
+        - '{{ .Values.bfl.username }}'
         - --log-level
         - debug
         ports:
@@ -297,7 +297,7 @@ spec:
         command:
         - /bfl-ingress
         - -user
-        - {{ .Values.bfl.username }}
+        - '{{ .Values.bfl.username }}'
         - -enable-nginx
         - -bfl-svc
         - bfl


### PR DESCRIPTION

* **What kind of change does this PR introduce?** 

`bug fix`: orion GPU runtime broken on Ubuntu 22.04