### PR TITLE
feat: manually chunk in files and context down to 1024 in dify

### DIFF
--- a/apps/files/config/user/helm-charts/files/templates/files_deploy.yaml
+++ b/apps/files/config/user/helm-charts/files/templates/files_deploy.yaml
@@ -92,7 +92,7 @@ spec:
           value: system-server.user-system-{{ .Values.bfl.username }}
 
       - name: files
-        image: beclab/files-server:v0.2.18
+        image: beclab/files-server:v0.2.19
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: fb-data

--- a/apps/nitro/config/cluster/deploy/dify_deploy.yaml
+++ b/apps/nitro/config/cluster/deploy/dify_deploy.yaml
@@ -844,7 +844,7 @@ spec:
               - SYS_ADMIN
       {{- if and .Values.gpu (not (eq .Values.gpu "none" )) }}
       - name: nitro
-        image: 'beclab/nitro:v0.0.2'
+        image: 'beclab/nitro:v0.0.3'
         ports:
           - name: nitro-port
             containerPort: 3928
@@ -858,7 +858,7 @@ spec:
           - name: NGL_VALUE
             value: '33'
           - name: C_VALUE
-            value: '4096'
+            value: '1024'
           - name: OTHER_VALUES
           - name: PGID
             value: '1000'


### PR DESCRIPTION
change:

- files: manually chunk when pasting to sync to ensure dealing with files between 2G and 4G correctly
- dify: system model context from 4096 down to 1024 for running more stable