### PR TITLE
ci: independent daily-build install script

### DIFF
--- a/.github/workflows/release-daily.yaml
+++ b/.github/workflows/release-daily.yaml
@@ -46,6 +46,7 @@ jobs:
           aws s3 cp install-wizard-v${{ steps.vars.outputs.tag_version }}.tar.gz s3://terminus-os-install/install-wizard-v${{ steps.vars.outputs.tag_version }}.tar.gz --acl=public-read
 
   release:
+    needs: upload-full
     runs-on: ubuntu-latest
 
     steps:
@@ -73,7 +74,7 @@ jobs:
       - name: Update release version
         uses: eball/write-tag-to-version-file@latest
         with:
-          filename: 'build/installer/publicInstaller.sh'
+          filename: 'build/installer/install.sh'
           placeholder: '#__VERSION__'
           tag: ${{ steps.vars.outputs.tag_version }}
 
@@ -100,6 +101,7 @@ jobs:
             build/installer/publicInstaller.sh
             build/installer/publicInstaller.latest
             build/installer/uninstall_cmd.sh
+            build/installer/install.sh
             build/installer/publicAddnode.sh
             build/installer/version.hint
             build/installer/publicRestoreInstaller.sh

--- a/.github/workflows/release-daily.yaml
+++ b/.github/workflows/release-daily.yaml
@@ -9,6 +9,42 @@ on:
   workflow_dispatch:
 
 jobs:
+  upload-full:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 21200
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+
+      - name: 'Daily tag version'
+        id: vars
+        run: |
+          v=1.6.0-$(date +"%Y%m%d")
+          echo "tag_version=$v" >> $GITHUB_OUTPUT
+          echo "latest_version=1.4.4" >> $GITHUB_OUTPUT
+
+      - name: 'Checkout source code'
+        uses: actions/checkout@v3
+
+      - name: Package installer
+        run: |
+          bash scripts/build-full.sh ${{ steps.vars.outputs.tag_version }}
+
+      - name: Upload to S3
+        env: 
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+        run: |
+          aws s3 cp install-wizard-v${{ steps.vars.outputs.tag_version }}.tar.gz s3://terminus-os-install/install-wizard-v${{ steps.vars.outputs.tag_version }}.tar.gz --acl=public-read
+
   release:
     runs-on: ubuntu-latest
 
@@ -31,6 +67,13 @@ jobs:
         uses: eball/write-tag-to-version-file@latest
         with:
           filename: 'build/installer/wizard/config/settings/templates/terminus_cr.yaml'
+          placeholder: '#__VERSION__'
+          tag: ${{ steps.vars.outputs.tag_version }}
+
+      - name: Update release version
+        uses: eball/write-tag-to-version-file@latest
+        with:
+          filename: 'build/installer/publicInstaller.sh'
           placeholder: '#__VERSION__'
           tag: ${{ steps.vars.outputs.tag_version }}
 

--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -4,13 +4,14 @@
 
 set -o pipefail
 
+VERSION="#__VERSION__"
 if [ "x${VERSION}" = "x" ]; then
   echo "Unable to get latest Install-Wizard version. Set VERSION env var and re-run. For example: export VERSION=1.0.0"
   echo ""
   exit
 fi
 
-DOWNLOAD_URL="https://github.com/beclab/terminus/releases/download/${VERSION}/install-wizard-v${VERSION}.tar.gz"
+DOWNLOAD_URL="https://dc3p1870nn3cj.cloudfront.net/install-wizard-v${VERSION}.tar.gz"
 
 echo ""
 echo " Downloading Install-Wizard ${VERSION} from ${DOWNLOAD_URL} ... " 

--- a/build/installer/publicInstaller.sh
+++ b/build/installer/publicInstaller.sh
@@ -4,13 +4,14 @@
 
 set -o pipefail
 
+VERSION="#__VERSION__"
 if [ "x${VERSION}" = "x" ]; then
   echo "Unable to get latest Install-Wizard version. Set VERSION env var and re-run. For example: export VERSION=1.0.0"
   echo ""
   exit
 fi
 
-DOWNLOAD_URL="https://github.com/beclab/terminus/releases/download/${VERSION}/install-wizard-v${VERSION}.tar.gz"
+DOWNLOAD_URL="https://dc3p1870nn3cj.cloudfront.net/install-wizard-v${VERSION}.tar.gz"
 
 echo ""
 echo " Downloading Install-Wizard ${VERSION} from ${DOWNLOAD_URL} ... " 


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

`ci/cd`: use an independent daily-build install script for the daily-build version installing,  keep the publicInstaller.sh for Terminus Space itself.