### PR TITLE
feat: l4 proxy & bfl ingress arm64 supported

### DIFF
--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -280,7 +280,7 @@ spec:
         - name: BACKUP_SERVER
           value: backup-server.os-system:8082
         - name: L4_PROXY_IMAGE_VERSION
-          value: v0.2.5
+          value: v0.2.6
         - name: FRPC_IMAGE_VERSION
           value: v1.0.2
         - name: CLOUDFLARED_IMAGE_NAME
@@ -289,7 +289,7 @@ spec:
           value: v0.1.0
 
       - name: ingress
-        image: beclab/bfl-ingress:v0.2.8
+        image: beclab/bfl-ingress:v0.2.9
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: ngxlog


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
`feature`: patch nginx base image to supported arm64, fix l4-bfl-proxy and bfl-ingress arm64 version nginx exec file format error.

