### PR TITLE
fix: nitro nginx config spell error

### DIFF
--- a/apps/nitro/config/cluster/deploy/nitro_deploy.yaml
+++ b/apps/nitro/config/cluster/deploy/nitro_deploy.yaml
@@ -25,7 +25,7 @@ data:
 
       location /wasm/model_server/ {
           proxy_pass http://nitro:8081/;
-          inlcude proxy.conf;
+          include proxy.conf;
       }
 
       location /nitro/ {


### PR DESCRIPTION
fix:
- nitro: nginx config spell error