### PR TITLE
fix: bump juicefs-ext to 11.1.1

### DIFF
--- a/build/installer/install_cmd.sh
+++ b/build/installer/install_cmd.sh
@@ -1210,7 +1210,7 @@ _END
 }
 
 install_juicefs() {
-    JFS_VERSION="v11.1.0"
+    JFS_VERSION="v11.1.1"
 
     log_info 'start to install juicefs'
 

--- a/build/installer/publicAddnode.sh
+++ b/build/installer/publicAddnode.sh
@@ -546,7 +546,7 @@ prepare_storage() {
 }
 
 install_juicefs() {
-    JFS_VERSION="v11.1.0"
+    JFS_VERSION="v11.1.1"
 
     log_info 'start to install juicefs'
     local juicefs_data="${TERMINUS_ROOT}/data/juicefs"

--- a/build/installer/upgrade_cmd.sh
+++ b/build/installer/upgrade_cmd.sh
@@ -405,7 +405,7 @@ function upgrade_ksapi(){
 
 function upgrade_jfs(){
     local users=$@
-    local JFS_VERSION="11.1.0"
+    local JFS_VERSION="11.1.1"
     local current_jfs_version=$(/usr/local/bin/juicefs --version|awk '{print $3}'|awk -F'+' '{print $1}')
 
     if [ "x${JFS_VERSION}" != "x${current_jfs_version}" ]; then

--- a/build/manifest/dependencies.amd64
+++ b/build/manifest/dependencies.amd64
@@ -9,7 +9,7 @@ https://github.com/beclab/minio-operator/releases/download/v0.0.1/minio-operator
 
 https://download.redis.io/releases/redis-5.0.14.tar.gz,redis-5.0.14.tar.gz
 
-https://github.com/beclab/juicefs-ext/releases/download/v11.1.0/juicefs-v11.1.0-linux-amd64.tar.gz,juicefs-v11.1.0-linux-amd64.tar.gz
+https://github.com/beclab/juicefs-ext/releases/download/v11.1.1/juicefs-v11.1.1-linux-amd64.tar.gz,juicefs-v11.1.1-linux-amd64.tar.gz
 
 https://github.com/beclab/velero/releases/download/v1.11.3/velero-v1.11.3-linux-amd64.tar.gz,velero-v1.11.3-linux-amd64.tar.gz
 

--- a/build/manifest/dependencies.arm64
+++ b/build/manifest/dependencies.arm64
@@ -9,7 +9,7 @@ https://github.com/beclab/minio-operator/releases/download/v0.0.1/minio-operator
 
 https://download.redis.io/releases/redis-5.0.14.tar.gz,redis-5.0.14.tar.gz
 
-https://github.com/beclab/juicefs-ext/releases/download/v11.1.0/juicefs-v11.1.0-linux-arm64.tar.gz,juicefs-v11.1.0-linux-arm64.tar.gz
+https://github.com/beclab/juicefs-ext/releases/download/v11.1.1/juicefs-v11.1.1-linux-arm64.tar.gz,juicefs-v11.1.1-linux-arm64.tar.gz
 
 https://github.com/beclab/velero/releases/download/v1.11.3/velero-v1.11.3-linux-arm64.tar.gz,velero-v1.11.3-linux-arm64.tar.gz
 


### PR DESCRIPTION


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

fix: bump juicefs-ext to 11.1.1


