### PR TITLE
fix: copy back install.sh after version string is injected

### DIFF
--- a/.github/workflows/release-daily.yaml
+++ b/.github/workflows/release-daily.yaml
@@ -123,9 +123,9 @@ jobs:
           bash scripts/build.sh ${{ steps.vars.outputs.tag_version }}
 
       - name: 'Archives'
-        working-directory: ./build/installer
         run: |
-          cp install.sh publicInstaller.sh
+          cp .dist/install-wizard/installer.sh build/installer
+          cp build/installer/installer.sh build/installer/publicInstaller.sh
 
       - name: Release public files
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,10 +97,10 @@ jobs:
           bash scripts/build.sh ${{ steps.vars.outputs.tag_version }}
           
       - name: 'Archives'
-        working-directory: ./build/installer
         run: |
-          cp install.sh publicInstaller.sh
-          cp install.sh publicInstaller.latest
+          cp .dist/install-wizard/installer.sh build/installer
+          cp build/installer/installer.sh build/installer/publicInstaller.sh
+          cp build/installer/installer.sh build/installer/publicInstaller.latest
 
       - name: Release public files
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
the current released `install.sh` will not have a valid `Version`, resulting in failure of execution.
```
curl -ssLO https://github.com/beclab/Terminus/releases/download/1.8.0-20240917/install.sh
❯ chmod +x install.sh
❯ ./install.sh
Unable to get latest Install-Wizard version. Set VERSION env var and re-run. For example: export VERSION=1.0.0
```
the cause is:

in the action spec, the released `install.sh` is copied from `build/installer`:

https://github.com/beclab/Terminus/blob/896ece5975f825a43b4635bffe2455d76ec55e9d/.github/workflows/release-daily.yaml#L125-L128

whereas the version string injection is done to the copied `install.sh` under `.dist/install-wizard`:
https://github.com/beclab/Terminus/blob/896ece5975f825a43b4635bffe2455d76ec55e9d/scripts/package.sh#L12
https://github.com/beclab/Terminus/blob/896ece5975f825a43b4635bffe2455d76ec55e9d/scripts/package.sh#L22
https://github.com/beclab/Terminus/blob/896ece5975f825a43b4635bffe2455d76ec55e9d/scripts/build.sh#L23
https://github.com/beclab/Terminus/blob/896ece5975f825a43b4635bffe2455d76ec55e9d/scripts/build.sh#L39