### PR TITLE
fix: cli update to 0.1.29

### DIFF
--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -63,7 +63,7 @@ if command -v tar >/dev/null; then
     fi
 
 
-    CLI_VERSION="0.1.28"
+    CLI_VERSION="0.1.29"
     CLI_FILE="terminus-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
     INSTALL_TERMINUS_CLI="/usr/local/bin/terminus-cli"
     if [[ x"$os_type" == x"Darwin" ]]; then


### PR DESCRIPTION
- fix: no longer delete the share directory
- fix: remove the cli directory during the uninstall process up to the prepare stage
- fix: automatically retrieve the terminus version number and kube type during uninstallation