### PR TITLE
feat: files get resource recursive stream for folder downloading

### DIFF
--- a/apps/files/config/cluster/deploy/files_deploy.yaml
+++ b/apps/files/config/cluster/deploy/files_deploy.yaml
@@ -70,7 +70,7 @@ spec:
             - containerPort: 8080
           env:
             - name: FILES_SERVER_TAG
-              value: 'beclab/files-server:v0.2.35'
+              value: 'beclab/files-server:v0.2.37'
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -101,7 +101,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.35
+          image: beclab/files-server:v0.2.37
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -348,7 +348,7 @@ spec:
             chown -R 1000:1000 /appdata 
       containers:
         - name: files
-          image: beclab/files-server:v0.2.35
+          image: beclab/files-server:v0.2.37
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
files:
- GET /api/resource add recursive streaming style for folder downloading by "?stream=1"
- GET /api/resource add sync support by "?src=sync"
- Both of the params above can work together for sync folder downloading
- fix a new found bug for search3 when content is empty when the pod is restarting