### PR TITLE
feat: use domestic terminus cert&dns service if set

### DIFF
--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -62,7 +62,7 @@ if command -v tar >/dev/null; then
     fi
 
 
-    CLI_VERSION="0.1.32"
+    CLI_VERSION="0.1.33"
     CLI_FILE="terminus-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
     INSTALL_TERMINUS_CLI="/usr/local/bin/terminus-cli"
     if [[ x"$os_type" == x"Darwin" ]]; then

--- a/build/installer/install_cmd.sh
+++ b/build/installer/install_cmd.sh
@@ -195,7 +195,14 @@ EOF
 
     # clear apps values.yaml
     cat /dev/null > ${BASE_DIR}/wizard/config/apps/values.yaml
-    cat /dev/null > ${BASE_DIR}/wizard/config/launcher/values.yaml
+
+    # write default bfl values.yaml
+  cat > ${BASE_DIR}/wizard/config/launcher/values.yaml <<_EOF
+bfl:
+  terminus_cert_service_api: ${TERMINUS_CERT_SERVICE_API}
+  terminus_dns_service_api: ${TERMINUS_DNS_SERVICE_API}
+_EOF
+
     copy_charts=("launcher" "apps")
     for cc in "${copy_charts[@]}"; do
         retry_cmd $sh_c "${KUBECTL} cp ${BASE_DIR}/wizard/config/${cc} os-system/${appservice_pod}:/userapps -c app-service"
@@ -580,6 +587,8 @@ bfl:
   nodeport_ingress_https: 30082
   username: '${username}'
   admin_user: true
+  terminus_cert_service_api: ${TERMINUS_CERT_SERVICE_API}
+  terminus_dns_service_api: ${TERMINUS_DNS_SERVICE_API}
 _EOF
 
   sed -i "s/#__DOMAIN_NAME__/${domainname}/" ${BASE_DIR}/wizard/config/settings/templates/terminus_cr.yaml

--- a/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
+++ b/frameworks/app-service/config/cluster/deploy/appservice_deploy.yaml
@@ -148,7 +148,7 @@ spec:
       serviceAccount: os-internal
       containers:
       - name: app-service
-        image: beclab/app-service:0.2.42
+        image: beclab/app-service:0.2.43
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
+++ b/frameworks/bfl/config/launcher/templates/bfl_deploy.yaml
@@ -242,7 +242,7 @@ spec:
 
       containers:
       - name: api
-        image: beclab/bfl:v0.3.47
+        image: beclab/bfl:v0.3.48
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1000
@@ -289,6 +289,10 @@ spec:
           value: v0.2.6
         - name: REVERSE_PROXY_AGENT_IMAGE_VERSION
           value: v0.1.3
+        - name: TERMINUS_CERT_SERVICE_API
+          value: {{ .Values.bfl.terminus_cert_service_api }}
+        - name: TERMINUS_DNS_SERVICE_API
+          value: {{ .Values.bfl.terminus_dns_service_api }}
 
       - name: ingress
         image: beclab/bfl-ingress:v0.2.14


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the new behavior (if this is a feature change)?**

if the environment variable `TERMINUS_CERT_SERVICE_API` is set, it will be used instead of the default `https://terminus-cert.snowinning.com`

if the environment variable `TERMINUS_DNS_SERVICE_API` is set, it will be used instead of the default `https://terminus-dnsop.snowinning.com`