### PR TITLE
fix: deadlock in jfsnotify-proxy where client watcher crash

### DIFF
--- a/libs/fs-lib/config/cluster/deploy/fsnotify_deploy.yaml
+++ b/libs/fs-lib/config/cluster/deploy/fsnotify_deploy.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccount: os-internal
       containers:
         - name: proxy
-          image: beclab/fsnotify-proxy:0.1.9
+          image: beclab/fsnotify-proxy:0.1.10
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5079

--- a/libs/fs-lib/config/user/helm-charts/fsnotify/templates/fsnotify_deploy.yaml
+++ b/libs/fs-lib/config/user/helm-charts/fsnotify/templates/fsnotify_deploy.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: bytetrade-sys-ops
       containers:
       - name: proxy
-        image: beclab/fsnotify-proxy:0.1.9
+        image: beclab/fsnotify-proxy:0.1.10
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5079


### PR DESCRIPTION


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

fix: deadlock in jfsnotify-proxy where client watcher crash

