### PR TITLE
fix: files-server won't read header for every files when checking filetype at listing (GET /api/resources) to avoid taking a lot of time for reading content from a downloading file

### DIFF
--- a/apps/files/config/cluster/deploy/files_deploy.yaml
+++ b/apps/files/config/cluster/deploy/files_deploy.yaml
@@ -70,7 +70,7 @@ spec:
             - containerPort: 8080
           env:
             - name: FILES_SERVER_TAG
-              value: 'beclab/files-server:v0.2.38'
+              value: 'beclab/files-server:v0.2.39'
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -101,7 +101,7 @@ spec:
 {{ end }}
 
         - name: files
-          image: beclab/files-server:v0.2.38
+          image: beclab/files-server:v0.2.39
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -348,7 +348,7 @@ spec:
             chown -R 1000:1000 /appdata 
       containers:
         - name: files
-          image: beclab/files-server:v0.2.38
+          image: beclab/files-server:v0.2.39
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
fix: 
-files: files-server won't read header for every files when checking filetype at listing (GET /api/resources) to avoid taking a lot of time for reading content from a downloading file