### PR TITLE
fix: use helm templating instead of sed replace

### DIFF
--- a/build/installer/install.sh
+++ b/build/installer/install.sh
@@ -62,7 +62,7 @@ if [ ! -d $BASE_DIR ]; then
     mkdir -p $BASE_DIR
 fi
 
-CLI_VERSION="0.1.44"
+CLI_VERSION="0.1.45"
 CLI_FILE="terminus-cli-v${CLI_VERSION}_linux_${ARCH}.tar.gz"
 if [[ x"$os_type" == x"Darwin" ]]; then
     CLI_FILE="terminus-cli-v${CLI_VERSION}_darwin_${ARCH}.tar.gz"

--- a/build/installer/wizard/config/settings/templates/terminus_cr.yaml
+++ b/build/installer/wizard/config/settings/templates/terminus_cr.yaml
@@ -30,8 +30,8 @@ spec:
       owner: beclab
       repo: terminus
   settings: 
-    domainName: "#__DOMAIN_NAME__"
-    selfhosted: "#__SELFHOSTED__"
+    domainName: '{{ .Values.domainName }}'
+    selfhosted: '{{ .Values.selfHosted }}'
     terminusd: '{{ .Values.terminusd }}'
 status:
   state: active


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
the legacy way of replacing holder string in yaml files (notably the terminus_cr.yaml) before applying it may cause a problem that, if the OS is uninstalled and then installed again, the modified yaml files will remain replaced,
and the replace operation done by the new installation process will not take any effect, resulting in inconsistent behaviors.


* **What is the new behavior (if this is a feature change)?**
using helm values instead, to keep the files unchanged throughout multiple installations
